### PR TITLE
Revert "Make a symlink to libcommon_clang"

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,4 +18,3 @@ cmake \
 make -j${CPU_COUNT} VERBOSE=1
 make install
 
-ln -sf $PREFIX/lib/libopencl_clang.so $PREFIX/lib/libcommon_clang.so

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: eb7208ee91bd77c365617424cdf776e33cb2900516430564afabc84892c1937e
 
 build:
-  number: 2
+  number: 3
   skip: true  # [not linux]
 
 requirements:


### PR DESCRIPTION
This reverts commit f75e94dcd518c6b40a62a39e6ed4cd4154998236.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
